### PR TITLE
toc edits

### DIFF
--- a/services/SPLICE-PreCAT-Notification-Dialogs-for-Insurance-Companies/toc
+++ b/services/SPLICE-PreCAT-Notification-Dialogs-for-Insurance-Companies/toc
@@ -4,7 +4,7 @@
 {: .toc subcollection="SPLICE-PreCAT-Notification-Dialogs-for-Insurance-Companies" audience="service" href="/docs/services/SPLICE-PreCAT-Notification-Dialogs-for-Insurance-Companies/index.html"}
 SPLICE Pre-Cat Insurance Notifications
 
-   {: .navgroup id="reference"}
-   index.md
-   [API Documentation](developers.splicesoftware.com){: new_window}
-   {: .navgroup-end}
+    {: .navgroup id="reference"}
+    index.md
+    [API Documentation](developers.splicesoftware.com)
+    {: .navgroup-end}


### PR DESCRIPTION
I added a space to each line so that     
```
    {: .navgroup id="reference"}
    index.md
    [API Documentation](developers.splicesoftware.com)
    {: .navgroup-end}
```

are all indented 4 spaces. I also removed the new window tag which is not necessary.