### PR TITLE
Removed first H1

### DIFF
--- a/services/Rational-Exuberance/index.md
+++ b/services/Rational-Exuberance/index.md
@@ -1,4 +1,3 @@
-# Rational Exuberance
 ---
 
 copyright:


### PR DESCRIPTION
You can only have 1 H1 and because there was one above the date/copyright metadata, it was messing up the content on the page