### PR TITLE
Fix copyright date

### DIFF
--- a/services/Bosch-IoT-Rollouts/index.md
+++ b/services/Bosch-IoT-Rollouts/index.md
@@ -1,6 +1,6 @@
 ---
 
-copyright: "Bosch Software Innovations GmbH, Germany"
+copyright:
 
   years:  2017
 


### PR DESCRIPTION
By adding "Bosch Software Innovations GmbH, Germany" to the copyright metadata, it breaks the formatting in the output of the page.