### PR TITLE
New URL for the Mendix starter app tutorial

### DIFF
--- a/services/Mendix-Rapid-Application-Development-Platform/toc
+++ b/services/Mendix-Rapid-Application-Development-Platform/toc
@@ -10,7 +10,7 @@ Mendix  Platform
     {: .topicgroup}
     Related links
         [API Documentation](https://docs.mendix.com/developerportal/deploy/ibm-cloud)
-        [Mendix Starter App Tutorial](https://docs.mendix.com/howto/tutorials/starter-apps)
+        [Mendix Introductory Tutorial](https://gettingstarted.mendixcloud.com/link/path/14)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}


### PR DESCRIPTION
Mendix will be removing the link here as this tutorial is duplicated. The new link points at the maintained version of the tutorial.