### PR TITLE
A few syntax errors in toc

### DIFF
--- a/services/Actifio-GO/toc
+++ b/services/Actifio-GO/toc
@@ -6,20 +6,22 @@ Actifio GO!
 
     {: .navgroup id="learn"}
     index.md
+
     {: .topicgroup}
     Related links
         [API Documentation](https://www.actifio.com/#sthash.UsBMotCh.dpbs)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}
+
     {: .topicgroup}
     Reference
         [Company homepage](https://portal.dev.actifiogo.com/)
     {: .navgroup-end}
 
     {: .navgroup id="help"}
+    
     {: .topicgroup}
     Help
         [Support](https://portal.dev.actifiogo.com/)
     {: .navgroup-end}
-


### PR DESCRIPTION
I updated this toc with a few syntax corrections, particularly with spacing between navgroup and topic group.