### PR TITLE
Update index to include a new link

### DIFF
--- a/services/HPCaaS-from-Rescale/index.md
+++ b/services/HPCaaS-from-Rescale/index.md
@@ -34,6 +34,7 @@ Review the "Standard" pricing plan and click on the "Create" button to instantia
 Click on the "Launch" button to launch the Rescale control plane and start defining and managing your HPC jobs.
 
 More details about HPCaaS from Rescale can be found [here](https://resources.rescale.com/documentation)
+
 Demo collections about HPCaaS from Rescale can be found [here](https://www.ibm.com/demos/collection/HPCaaS-From-Rescale/){:new_window}.
 
 ## Pricing Plans and Billing

--- a/services/HPCaaS-from-Rescale/index.md
+++ b/services/HPCaaS-from-Rescale/index.md
@@ -33,9 +33,9 @@ Review the "Standard" pricing plan and click on the "Create" button to instantia
 ### Step Three:
 Click on the "Launch" button to launch the Rescale control plane and start defining and managing your HPC jobs.
 
-More details about HPCaaS from Rescale can be found [here](https://resources.rescale.com/documentation)
+More details on HPCaaS from Rescale can be found [here](https://resources.rescale.com/documentation).
 
-Demo collections about HPCaaS from Rescale can be found [here](https://www.ibm.com/demos/collection/HPCaaS-From-Rescale/){:new_window}.
+A demo collection of HPCaaS from Rescale can be found [here](https://www.ibm.com/demos/collection/HPCaaS-From-Rescale/){:new_window}.
 
 ## Pricing Plans and Billing
  

--- a/services/HPCaaS-from-Rescale/index.md
+++ b/services/HPCaaS-from-Rescale/index.md
@@ -33,7 +33,8 @@ Review the "Standard" pricing plan and click on the "Create" button to instantia
 ### Step Three:
 Click on the "Launch" button to launch the Rescale control plane and start defining and managing your HPC jobs.
 
-More details about HPCaaS from Rescale can be found [here](https://resources.rescale.com/documentation){:new_window}.
+More details about HPCaaS from Rescale can be found [here](https://resources.rescale.com/documentation)
+Demo collections about HPCaaS from Rescale can be found [here](https://www.ibm.com/demos/collection/HPCaaS-From-Rescale/){:new_window}.
 
 ## Pricing Plans and Billing
  


### PR DESCRIPTION
On the Getting Started documentation link https://cloud.ibm.com/docs/services/HPCaaS-from-Rescale?topic=HPCaaS%20from%20Rescale-gettingstarted, we would like to add a reference to DTE assets.

​https://www.ibm.com/demos/collection/HPCaaS-From-Rescale/​